### PR TITLE
Fix: Include createdAt and updatedAt fields in property aggregation

### DIFF
--- a/Controller/AdminController/FrontController/PostPropertyController.js
+++ b/Controller/AdminController/FrontController/PostPropertyController.js
@@ -530,7 +530,9 @@ class PostPropertyController {
                 email: "$postProperty.email",
                 number: "$postProperty.number",
                 verify: "$postProperty.verify",
-                propertyLooking: "$postProperty.propertyLooking"
+                propertyLooking: "$postProperty.propertyLooking",
+                createdAt: "$postProperty.createdAt",
+                updatedAt: "$postProperty.updatedAt",
               }
             },
             { $sort: { [sortByField]: sortOrder } },


### PR DESCRIPTION
This commit fixes an issue where the `createdAt` and `updatedAt` fields were missing from the aggregated property data. The changes include:

-   Adding `createdAt` and `updatedAt` fields to the projection in the property aggregation pipeline in `PostPropertyController.js`.
-   This ensures that these fields are included in the response, providing more complete property information.