### PR TITLE
feat: Add property verification filter to property aggregation

### DIFF
--- a/Controller/AdminController/FrontController/PostPropertyController.js
+++ b/Controller/AdminController/FrontController/PostPropertyController.js
@@ -15,6 +15,7 @@ const {
   deleteFile,
   updateFile,
 } = require("../../../Utilities/s3HelperUtility");
+const { match } = require("assert");
 
 // Function to get all project data and cache it
 const getAllProjects = async () => {
@@ -486,6 +487,7 @@ class PostPropertyController {
         limit =  '10',
         sortByField = 'createdAt',
         sortBy = 'desc',
+        verify = 'verified',
       } = req.query;
 
       const pageNumber = parseInt(page);
@@ -493,7 +495,7 @@ class PostPropertyController {
       const skip = (pageNumber - 1) * limitNumber;
       const sortOrder = sortBy === "desc" ? -1 : 1;
 
-      const cachedData = cache.get(`allProperties-${skip}-${limit}-${sortOrder}`);
+      const cachedData = cache.get(`allProperties-${skip}-${limit}-${sortOrder}-${verify}`);
 
       if (cachedData) {
         return res.status(200).json({
@@ -504,6 +506,11 @@ class PostPropertyController {
       // If cache is empty, fetch from database
       const data = await postPropertyModel.aggregate([
         {$unwind:"$postProperty"},
+        {
+          $match:{
+            "postProperty.verify": verify === "verified" ? "verified" : "unverified"
+          }
+        },
         {
           $facet:{
           metadata:[{ $count:"total" }],
@@ -530,6 +537,7 @@ class PostPropertyController {
                 email: "$postProperty.email",
                 number: "$postProperty.number",
                 verify: "$postProperty.verify",
+                isVerified: { $eq:["$postProperty.verify","verified"] },
                 propertyLooking: "$postProperty.propertyLooking",
                 createdAt: "$postProperty.createdAt",
                 updatedAt: "$postProperty.updatedAt",
@@ -566,6 +574,7 @@ class PostPropertyController {
       });
     }
   };
+
   // static postPerson_View = async (req, res) => {
   //     try {
   //         const cachedData = cache.get('allProjects');


### PR DESCRIPTION
This commit introduces a filter to the property aggregation logic, allowing retrieval of properties based on their verification status.

The changes include:

-   Adding a `verify` query parameter to the `PostPropertyController.js` to filter properties based on their verification status ("verified" or "unverified").
-   Adding a `$match` stage to the aggregation pipeline to filter properties based on the `verify` field.
-   Adding `isVerified` field to the aggregated property data to indicate verification status.
-   Updating the cache key to include the `verify` parameter, ensuring that different verification states are cached separately.