### PR TITLE
fix: Update totalPages calculation to use Math.ceil for accurate pagination

### DIFF
--- a/Controller/AdminController/FrontController/BlogController.js
+++ b/Controller/AdminController/FrontController/BlogController.js
@@ -73,7 +73,7 @@ class blogController {
         res.status(200).json({
           message: "Data get successfull ! ",
           data,
-          totalPages: Math.floor(totalBlogs / limit),
+          totalPages: Math.ceil(totalBlogs / limit),
         });
       } else {
         res.status(200).json({
@@ -102,7 +102,7 @@ class blogController {
         return res.status(200).json({
           message: "Data get successfull ! ",
           data,
-          totalPages: Math.floor(totalDrafts/limit)
+          totalPages: Math.ceil(totalDrafts/limit)
         });
       } else {
         return res.status(200).json({


### PR DESCRIPTION
This commit modifies the totalPages calculation in the blogController to use Math.ceil instead of Math.floor, ensuring that the total number of pages is rounded up correctly. This change improves the accuracy of pagination in the API responses for both blogs and drafts.