### PR TITLE
ain problem backend me hai! Backend S3 ListObjects call me kuch galat…

### DIFF
--- a/routes/s3Routes.js
+++ b/routes/s3Routes.js
@@ -238,7 +238,7 @@ router.get('/images/:folder', verifyAdmin, async (req, res) => {
     const data = await s3.listObjectsV2(params).promise();
 
     // Filter only image files
-    const imageExtensions = ['.jpg', '.jpeg', '.png', '.webp', '.gif'];
+    const imageExtensions = ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.jfif'];
     const images = data.Contents
       .filter(item => {
         const ext = path.extname(item.Key).toLowerCase();


### PR DESCRIPTION
… kar raha hai. Console logs share karo, main backend fix suggest karunga.

Feedback submitted

do fix and display apply direc;lty

1
Inspect current S3 fetch response and identify why images array is empty

Modify frontend/backend interaction to correctly retrieve uploaded images

Verify images display in S3Manager after upload

Fast Context
get('/api/s3/images
in 4.27s
s3Routes.js
+1
-1
Inspect current S3 fetch response and identify why images array is empty

2
Modify frontend/backend interaction to correctly retrieve uploaded images

1 more
Summary
Added .jfif to the allowed image extensions in the backend’s S3 image listing so files such as *.jfif are now returned. backend/routes/s3Routes.js
*
Next steps
Restart the backend server so the route change takes effect. Reload the S3 Manager and tap Refresh on the right. The previously uploaded .jfif image should now appear in the aaaa folder. Feedback submitted

Code

GPT-5-Codex